### PR TITLE
Support incremental compilation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = "1.3.31"
+    ext.kotlin_version = "1.3.40"
     ext.bintray_version = "1.8.4"
 
     repositories {

--- a/kson-processor/build.gradle
+++ b/kson-processor/build.gradle
@@ -12,7 +12,7 @@ version = kson.version
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    compile 'com.squareup:kotlinpoet:0.7.0'
+    compile 'com.squareup:kotlinpoet:1.3.0'
     compile 'com.google.code.gson:gson:2.8.2'
 
     compile project(':kson-annotation')
@@ -20,4 +20,7 @@ dependencies {
     testCompile "junit:junit:4.12"
     testCompile "org.assertj:assertj-core:3.10.0"
     testCompile "org.jetbrains.kotlin:kotlin-test"
+
+    compile "net.ltgt.gradle.incap:incap:0.2"
+    kapt "net.ltgt.gradle.incap:incap-processor:0.2"
 }

--- a/kson-processor/build.gradle
+++ b/kson-processor/build.gradle
@@ -23,4 +23,7 @@ dependencies {
 
     compile "net.ltgt.gradle.incap:incap:0.2"
     kapt "net.ltgt.gradle.incap:incap-processor:0.2"
+
+    compile "com.google.auto.service:auto-service-annotations:1.0-rc5"
+    kapt "com.google.auto.service:auto-service:1.0-rc5"
 }

--- a/kson-processor/src/main/kotlin/dev/afanasev/kson/processor/KProperty.kt
+++ b/kson-processor/src/main/kotlin/dev/afanasev/kson/processor/KProperty.kt
@@ -19,7 +19,7 @@ internal fun typeToAdapterName(type: TypeName): String {
     if (type is ParameterizedTypeName) {
         names.addAll(type.getClassNamesRecursively())
     } else {
-        names.add((type as ClassName).simpleName())
+        names.add((type as ClassName).simpleName)
     }
 
     names.add("adapter")
@@ -29,13 +29,13 @@ internal fun typeToAdapterName(type: TypeName): String {
 
 private fun ParameterizedTypeName.getClassNamesRecursively(): List<String> {
     val names = mutableListOf<String>()
-    names.add(rawType.simpleName())
+    names.add(rawType.simpleName)
 
     typeArguments.forEach {
         if (it is ParameterizedTypeName) {
             names.addAll(it.getClassNamesRecursively())
         } else {
-            names.add((it as ClassName).simpleName())
+            names.add((it as ClassName).simpleName)
         }
     }
 

--- a/kson-processor/src/main/kotlin/dev/afanasev/kson/processor/KotlinPoetExtensions.kt
+++ b/kson-processor/src/main/kotlin/dev/afanasev/kson/processor/KotlinPoetExtensions.kt
@@ -1,0 +1,33 @@
+package dev.afanasev.kson.processor
+
+import com.squareup.kotlinpoet.*
+import javax.lang.model.element.TypeElement
+import kotlin.reflect.KClass
+
+fun ClassName.asNullable() = copy(nullable = true)
+
+fun TypeName.asNullable() = copy(nullable = true)
+
+fun KClass<*>.parameterizedBy(typeElement: TypeElement): ParameterizedTypeName {
+    return with(ParameterizedTypeName.Companion) {
+        asClassName().parameterizedBy(typeElement.asClassName())
+    }
+}
+
+fun KClass<*>.parameterizedBy(typeVariableName: TypeVariableName): ParameterizedTypeName {
+    return with(ParameterizedTypeName.Companion) {
+        asClassName().parameterizedBy(typeVariableName)
+    }
+}
+
+fun KClass<*>.parameterizedBy(clazz: KClass<*>, vararg moreClasses: KClass<*>): ParameterizedTypeName {
+    return with(ParameterizedTypeName.Companion) {
+        moreClasses.fold(plusParameter(clazz)) { parameterized, clazz -> parameterized.plusParameter(clazz) }
+    }
+}
+
+fun ClassName.parameterizedBy(clazz: TypeName, vararg moreClasses: TypeName): ParameterizedTypeName {
+    return with(ParameterizedTypeName.Companion) {
+        moreClasses.fold(plusParameter(clazz)) { parameterized, clazz -> parameterized.plusParameter(clazz) }
+    }
+}

--- a/kson-processor/src/main/kotlin/dev/afanasev/kson/processor/KsonAdapterFactoryProcessor.kt
+++ b/kson-processor/src/main/kotlin/dev/afanasev/kson/processor/KsonAdapterFactoryProcessor.kt
@@ -1,5 +1,6 @@
 package dev.afanasev.kson.processor
 
+import com.google.auto.service.AutoService
 import com.google.gson.Gson
 import com.google.gson.TypeAdapter
 import com.google.gson.TypeAdapterFactory
@@ -9,6 +10,7 @@ import dev.afanasev.kson.annotation.Kson
 import dev.afanasev.kson.annotation.KsonFactory
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessor
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType
+import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.TypeElement
@@ -18,6 +20,7 @@ import javax.tools.Diagnostic
  * Generates a Gson [TypeAdapterFactory] for all [Kson] annotated classes.
  */
 @IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.AGGREGATING)
+@AutoService(Processor::class)
 class KsonAdapterFactoryProcessor : KsonProcessor() {
 
     override fun getSupportedAnnotationTypes() = setOf(

--- a/kson-processor/src/main/kotlin/dev/afanasev/kson/processor/KsonAdapterFactoryProcessor.kt
+++ b/kson-processor/src/main/kotlin/dev/afanasev/kson/processor/KsonAdapterFactoryProcessor.kt
@@ -1,0 +1,101 @@
+package dev.afanasev.kson.processor
+
+import com.google.gson.Gson
+import com.google.gson.TypeAdapter
+import com.google.gson.TypeAdapterFactory
+import com.google.gson.reflect.TypeToken
+import com.squareup.kotlinpoet.*
+import dev.afanasev.kson.annotation.Kson
+import dev.afanasev.kson.annotation.KsonFactory
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessor
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType
+import javax.annotation.processing.RoundEnvironment
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.TypeElement
+import javax.tools.Diagnostic
+
+/**
+ * Generates a Gson [TypeAdapterFactory] for all [Kson] annotated classes.
+ */
+@IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.AGGREGATING)
+class KsonAdapterFactoryProcessor : KsonProcessor() {
+
+    override fun getSupportedAnnotationTypes() = setOf(
+            Kson::class.java.name,
+            KsonFactory::class.java.name
+    )
+
+    override fun generate(roundEnv: RoundEnvironment) {
+        val classes = roundEnv.ksonAnnotatedClasses.toList()
+        if (classes.isNotEmpty()) {
+
+            val factories = roundEnv.getElementsAnnotatedWith(KsonFactory::class.java)
+                    .filter { it.kind == ElementKind.CLASS }
+                    .map { it as TypeElement }
+
+            when (factories.size) {
+                0 -> log("Consider using ${KsonFactory::class.qualifiedName} annotation to generate"
+                        + " a factory class for all type adapters", Diagnostic.Kind.WARNING)
+                1 -> {
+                    val factoryClass = factories.first()
+                    val factorySpec = generateTypeAdapterFactory(
+                            factoryClass = factoryClass,
+                            typeAdapterClasses = classes
+                    )
+                    FileSpec.get(factoryClass.asClassName().packageName, factorySpec).writeTo(processingEnv.filer)
+                }
+                else -> error("Only one class can be annotated with ${KsonFactory::class.qualifiedName}")
+            }
+        }
+    }
+
+    /**
+     * Generates a Gson [TypeAdapterFactory]
+     */
+    private fun generateTypeAdapterFactory(factoryClass: TypeElement, typeAdapterClasses: List<TypeElement>): TypeSpec {
+        log("generating a factory...")
+
+        val factoryBuilder = TypeSpec
+                .classBuilder("Kson${factoryClass.simpleName}")
+                .addOriginatingElement(factoryClass)
+                .addAnnotation(getGeneratedAnnotation())
+                .addSuperinterface(TypeAdapterFactory::class)
+
+        val generic = TypeVariableName.invoke("T")
+        val returnType = TypeAdapter::class.parameterizedBy(generic).asNullable()
+
+        val createMethod = FunSpec.builder("create")
+                .addModifiers(KModifier.OVERRIDE)
+                .addAnnotation(
+                        AnnotationSpec.builder(Suppress::class)
+                                .addMember("%S", "UNCHECKED_CAST")
+                                .build()
+                )
+                .addTypeVariable(generic)
+                .addParameter(GSON, Gson::class)
+                .addParameter(TYPE, TypeToken::class.parameterizedBy(generic))
+                .returns(returnType)
+
+        val resultVarName = "typeAdapter"
+
+        createMethod.addStatement("val %L = when {", resultVarName)
+
+        typeAdapterClasses
+                .onEach { factoryBuilder.addOriginatingElement(it) }
+                .map { it.asClassName() }
+                .forEach {
+                    val adapter = ClassName(it.packageName, getTypeAdapterClassName(it))
+                    createMethod.addStatement(
+                            "%T::class.java.isAssignableFrom(%L.rawType) -> %T(%L)", it, TYPE, adapter, GSON)
+                }
+
+        createMethod.addStatement("else -> null")
+        createMethod.addStatement("}")
+
+        createMethod.addStatement("return %L as? %T", resultVarName, returnType)
+
+        factoryBuilder.addFunction(createMethod.build())
+
+        return factoryBuilder.build()
+    }
+}

--- a/kson-processor/src/main/kotlin/dev/afanasev/kson/processor/KsonTypeAdapterProcessor.kt
+++ b/kson-processor/src/main/kotlin/dev/afanasev/kson/processor/KsonTypeAdapterProcessor.kt
@@ -1,5 +1,6 @@
 package dev.afanasev.kson.processor
 
+import com.google.auto.service.AutoService
 import com.google.gson.Gson
 import com.google.gson.TypeAdapter
 import com.google.gson.annotations.SerializedName
@@ -13,6 +14,7 @@ import dev.afanasev.kson.annotation.Kson
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessor
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType
 import org.jetbrains.annotations.Nullable
+import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.TypeElement
@@ -24,6 +26,7 @@ import kotlin.reflect.jvm.internal.impl.name.FqName
  * Generates a Gson [TypeAdapter] for all [Kson] annotated classes.
  */
 @IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.ISOLATING)
+@AutoService(Processor::class)
 class KsonTypeAdapterProcessor : KsonProcessor() {
 
     override fun getSupportedAnnotationTypes() = setOf(Kson::class.java.name)

--- a/kson-processor/src/main/kotlin/dev/afanasev/kson/processor/KsonTypeAdapterProcessor.kt
+++ b/kson-processor/src/main/kotlin/dev/afanasev/kson/processor/KsonTypeAdapterProcessor.kt
@@ -1,0 +1,232 @@
+package dev.afanasev.kson.processor
+
+import com.google.gson.Gson
+import com.google.gson.TypeAdapter
+import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonToken
+import com.google.gson.stream.JsonWriter
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import dev.afanasev.kson.annotation.Kson
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessor
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType
+import org.jetbrains.annotations.Nullable
+import javax.annotation.processing.RoundEnvironment
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.TypeElement
+import javax.lang.model.element.VariableElement
+import kotlin.reflect.jvm.internal.impl.builtins.jvm.JavaToKotlinClassMap
+import kotlin.reflect.jvm.internal.impl.name.FqName
+
+/**
+ * Generates a Gson [TypeAdapter] for all [Kson] annotated classes.
+ */
+@IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.ISOLATING)
+class KsonTypeAdapterProcessor : KsonProcessor() {
+
+    override fun getSupportedAnnotationTypes() = setOf(Kson::class.java.name)
+
+    override fun generate(roundEnv: RoundEnvironment) {
+        val filer = processingEnv.filer
+        roundEnv.ksonAnnotatedClasses.forEach {
+            val adapterClass = it.asClassName()
+            val adapterSpec = generateTypeAdapter(it)
+            FileSpec.get(adapterClass.packageName, adapterSpec).writeTo(filer)
+        }
+    }
+
+    /**
+     * Generates a Gson [TypeAdapter]
+     */
+    private fun generateTypeAdapter(clazz: TypeElement): TypeSpec {
+        log("generating a type adapter for ${clazz.simpleName}...")
+
+        val properties = clazz.enclosedElements
+                .asSequence()
+                .filter { it.kind == ElementKind.FIELD }
+                .map { it as VariableElement }
+                .map {
+                    val key = it.getAnnotation(SerializedName::class.java)?.value ?: it.simpleName
+                    val name = it.simpleName
+                    val type = it.asType().asTypeName()
+                    val nullable = it.getAnnotation(Nullable::class.java) != null
+
+                    KProperty(key.toString(), name.toString(), type, nullable)
+                }
+                .toList()
+
+        val typeAdapterBuilder = TypeSpec
+                .classBuilder(getTypeAdapterClassName(clazz.asClassName()))
+                .addOriginatingElement(clazz)
+                .addAnnotation(getGeneratedAnnotation())
+                .superclass(TypeAdapter::class.parameterizedBy(clazz))
+                .primaryConstructor(
+                        FunSpec.constructorBuilder()
+                                .addParameter(GSON, Gson::class)
+                                .build()
+                )
+                .addProperty(
+                        PropertySpec.builder(GSON, Gson::class)
+                                .initializer(GSON)
+                                .addModifiers(KModifier.PRIVATE)
+                                .build()
+                )
+
+        // init properties
+        properties
+                .distinctBy {
+                    it.adapterName
+                }
+                .forEach {
+                    val initializer = CodeBlock.builder()
+                    val type = with(ParameterizedTypeName.Companion) {
+                        TypeAdapter::class.asClassName().parameterizedBy(it.type)
+                    }
+
+                    if (it.type is ParameterizedTypeName) {
+                        initializer.add("%L.getAdapter(", GSON)
+                        getParameterizedTypeToken(initializer, it.type)
+                        initializer.add(") as %T", type.javaToKotlinType())
+                    } else {
+                        initializer.add("%L.getAdapter(%T::class.javaObjectType)", GSON, it.type.javaToKotlinType())
+                    }
+
+                    typeAdapterBuilder.addProperty(
+                            PropertySpec.builder(it.adapterName, type.javaToKotlinType(), KModifier.PRIVATE)
+                                    .delegate("lazy(LazyThreadSafetyMode.NONE) { %L }", initializer.build())
+                                    .build()
+                    )
+                }
+
+        // add write() function
+        typeAdapterBuilder.addFunction(generateWriteFunction(clazz, properties))
+
+        // add read() function
+        typeAdapterBuilder.addFunction(generateReadFunction(clazz, properties))
+
+        return typeAdapterBuilder.build()
+    }
+
+    /**
+     * Generates write() function
+     */
+    private fun generateWriteFunction(clazz: TypeElement, properties: List<KProperty>): FunSpec {
+        val writeFunc = FunSpec.builder("write")
+                .addModifiers(KModifier.OVERRIDE)
+                .addParameter(WRITER, JsonWriter::class)
+                .addParameter(OBJECT, clazz.asClassName().asNullable())
+
+        //region if
+        writeFunc.beginControlFlow("if (%L == null)", OBJECT)
+        writeFunc.addStatement("%L.nullValue()", WRITER)
+        writeFunc.addStatement("return")
+        writeFunc.endControlFlow()
+        //endregion if
+
+        writeFunc.addStatement("%L.beginObject()", WRITER)
+        properties.forEach {
+            writeFunc.addStatement("%L.name(%S)", WRITER, it.key)
+            writeFunc.addStatement("%L.write(%L, %L.%L)", it.adapterName, WRITER, OBJECT, it.name)
+        }
+        writeFunc.addStatement("%L.endObject()", WRITER)
+
+        return writeFunc.build()
+    }
+
+    /**
+     * Generates read() function
+     */
+    private fun generateReadFunction(clazz: TypeElement, properties: List<KProperty>): FunSpec {
+        val readFunc = FunSpec.builder("read")
+                .addModifiers(KModifier.OVERRIDE)
+                .addParameter(READER, JsonReader::class.java)
+                .returns(clazz.asClassName().asNullable())
+
+        readFunc.beginControlFlow("if (%L.peek() == %T.NULL)", READER, JsonToken::class)
+        readFunc.addStatement("%L.nextNull()", READER)
+        readFunc.addStatement("return null")
+        readFunc.endControlFlow()
+
+        properties.forEach {
+            readFunc.addStatement("var ${it.key}: %L = null", it.type.javaToKotlinType().asNullable())
+        }
+
+        readFunc.addStatement("%L.beginObject()", READER)
+
+        //region while
+        readFunc.beginControlFlow("while (%L.hasNext())", READER)
+
+        //region if
+        readFunc.beginControlFlow("if (%L.peek() == %T.NULL)", READER, JsonToken::class)
+        readFunc.addStatement("%L.nextNull()", READER)
+        readFunc.addStatement("continue")
+        readFunc.endControlFlow()
+        //endregion if
+
+        //region when
+        readFunc.beginControlFlow("when (%L.nextName())", READER)
+        properties.forEach {
+            readFunc.addStatement("%S -> %L = %L.read(%L)", it.key, it.key, it.adapterName, READER)
+        }
+        readFunc.addStatement("else -> %L.skipValue()", READER)
+        readFunc.endControlFlow()
+        //endregion when
+
+        readFunc.endControlFlow()
+        //endregion while
+
+        readFunc.addStatement("%L.endObject()", READER)
+
+        readFunc.addStatement("return %T(", clazz.asType())
+
+        properties.forEachIndexed { index, field ->
+            readFunc.addStatement("%L = %L%L%L",
+                    field.name,
+                    field.key,
+                    if (field.nullable) "" else "!!",
+                    if (index == properties.size - 1) "" else ","
+            )
+        }
+
+        readFunc.addStatement(")")
+
+        return readFunc.build()
+    }
+
+    private fun getParameterizedTypeToken(codeBlock: CodeBlock.Builder, type: ParameterizedTypeName, asType: Boolean = false) {
+        codeBlock.add("%T.getParameterized(%T::class.javaObjectType", TypeToken::class, type.rawType.javaToKotlinType())
+
+        type.typeArguments.forEach {
+            codeBlock.add(", ")
+
+            if (it is ParameterizedTypeName) {
+                getParameterizedTypeToken(codeBlock, it, true)
+            } else {
+                codeBlock.add("%T::class.javaObjectType", it.javaToKotlinType())
+            }
+        }
+
+        codeBlock.add(")")
+        if (asType) {
+            codeBlock.add(".getType()")
+        }
+    }
+
+    private fun TypeName.javaToKotlinType(): TypeName {
+        return if (this is ParameterizedTypeName) {
+            (rawType.javaToKotlinType() as ClassName).parameterizedBy(
+                    *typeArguments.map { it.javaToKotlinType() }.toTypedArray()
+            )
+        } else {
+            val className = JavaToKotlinClassMap.INSTANCE.mapJavaToKotlin(FqName(toString()))?.asSingleFqName()?.asString()
+
+            return if (className == null) {
+                this
+            } else {
+                ClassName.bestGuess(className)
+            }
+        }
+    }
+}

--- a/kson-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/kson-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,2 @@
-dev.afanasev.kson.processor.KsonProcessor
+dev.afanasev.kson.processor.KsonAdapterFactoryProcessor
+dev.afanasev.kson.processor.KsonTypeAdapterProcessor

--- a/kson-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/kson-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,2 +1,0 @@
-dev.afanasev.kson.processor.KsonAdapterFactoryProcessor
-dev.afanasev.kson.processor.KsonTypeAdapterProcessor

--- a/kson-processor/src/test/kotlin/dev/afanasev/kson/processor/KPropertyKtTest.kt
+++ b/kson-processor/src/test/kotlin/dev/afanasev/kson/processor/KPropertyKtTest.kt
@@ -1,6 +1,9 @@
 package dev.afanasev.kson.processor
 
-import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.asTypeName
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -14,18 +17,17 @@ class KPropertyKtTest {
         val string = ClassName.bestGuess("String")
         assert("string_adapter", string)
 
-        val listOfString = ParameterizedTypeName.get(List::class, String::class)
+        val listOfString = List::class.parameterizedBy(String::class)
         assert("list_string_adapter", listOfString)
 
-        val mapOfStringToInt = ParameterizedTypeName.get(Map::class, String::class, Int::class)
+        val mapOfStringToInt = Map::class.parameterizedBy(String::class, Int::class)
         assert("map_string_int_adapter", mapOfStringToInt)
 
-        val mapOfMap = ParameterizedTypeName.get(Map::class.asClassName(), Int::class.asTypeName(), mapOfStringToInt)
+        val mapOfMap = Map::class.asClassName().parameterizedBy(Int::class.asTypeName(), mapOfStringToInt)
         assert("map_int_map_string_int_adapter", mapOfMap)
     }
 
     private fun assert(expectedName: String, type: TypeName) {
         assertThat(typeToAdapterName(type)).isEqualTo(expectedName)
     }
-
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -16,6 +16,6 @@ dependencies {
 
 // Optional, let IDE know generated classes
 sourceSets {
-    main.java.srcDirs += "build/generated/source/kaptKotlin/main"
-    test.java.srcDirs += "build/generated/source/kaptKotlin/test"
+    main.java.srcDirs += "build/generated/source/kapt/main"
+    test.java.srcDirs += "build/generated/source/kapt/test"
 }


### PR DESCRIPTION
Support for https://github.com/aafanasev/kson/issues/5

So, what's going on is:

1. To support incremental compilation all files created by annotation processor have to be created using [```Filer```](https://docs.oracle.com/javase/7/docs/api/javax/annotation/processing/Filer.html). To do so I have to update ```KotlinPoet``` to latest version (1.3.0) which led to some methods being removed, moved or changed visibility. Thus, I created file ```KotlinPoetExtensions.kt``` with some extension methods to match old api.
2. Another thing is we should provide originating element to all files, so I have to change some methods to work with ```TypeElement``` instead of ```ClassName```.
3. I have to update Kotlin to version 1.3.40 because of [this](https://youtrack.jetbrains.com/issue/KT-31127) bug.
4. For better performance I split processor into two: one for generating ```TypeAdapter``` (this one is ```ISOLATING```) and one for generating ```TypeAdapterFactory``` (this one is ```AGGREGATING```).
5. I also use ```AutoService``` to register annotation processors which is more convenient imo.